### PR TITLE
Numba multiprocessing default set to 'spawn'

### DIFF
--- a/Stress_Test.py
+++ b/Stress_Test.py
@@ -1,6 +1,7 @@
 import numpy as np
 from timeit import default_timer as timer
 from numba import vectorize
+import multiprocessing as mp
 from multiprocessing import Process, Lock
 import time
 
@@ -61,6 +62,7 @@ def cpu_loop(loc, process_num):
 
 
 if __name__ == '__main__':
+    mp.set_start_method('spawn')
     cpu_cores = 8
     lock = Lock()
     all_processes = []


### PR DESCRIPTION
I was getting an error in Numba related to the way it was generating the GPU child processes. Turns out the issue can be solved by just changing the default method that Numba launches new processes. (https://numba.pydata.org/numba-doc/dev/user/faq.html#how-do-i-work-around-the-cuda-intialized-before-forking-error)